### PR TITLE
fix: match topic name to serverless format

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -9,8 +9,7 @@ functions:
   pong:
     handler: handler.pong
     events:
-      - sns:
-         topicName: test-topic
+      - sns: test-topic
   ping:
     handler: handler.ping
     events:
@@ -24,4 +23,4 @@ plugins:
 custom:
   serverless-offline-sns:
     port: 4002
-    debug: true 
+    debug: true


### PR DESCRIPTION
I get the following error when I try to deploy the function - 

```bash
$ sls deploy -v
Serverless: Packaging service...
Serverless: Excluding development dependencies...

  Serverless Error ---------------------------------------

  Missing or invalid topicName property for sns event in function "pong" The correct syntax is: sns: topic-name-or-arn OR an object with  arn and topicName OR topicName and displayName. Please check the docs for more info.

  Get Support --------------------------------------------
     Docs:          docs.serverless.com
     Bugs:          github.com/serverless/serverless/issues
     Issues:        forum.serverless.com

  Your Environment Information -----------------------------
     OS:                     darwin
     Node Version:           8.10.0
     Serverless Version:     1.28.0
```

According to https://github.com/serverless/serverless/pull/2796/, if we specify `topicName`, it needs `displayName` also. I took the other approach of specifying topic directly.
